### PR TITLE
New 'run' command

### DIFF
--- a/Desktopcommands/CommandDefinitions.xml
+++ b/Desktopcommands/CommandDefinitions.xml
@@ -9,4 +9,5 @@
   <Command name="Command_Shutdown" call="shutdown"></Command>
   <Command name="Command_Exit" call="exit" shortcall="x"></Command>
   <Command name="Command_Help" call="help" shortcall="h"></Command>
+  <Command name="Command_Run" call="run" shortcall="r"></Command>
 </Commands>

--- a/Desktopcommands/Commands/CommandUtilities/RegistryUtils.cs
+++ b/Desktopcommands/Commands/CommandUtilities/RegistryUtils.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Desktopcommands.Commands.CommandUtilities
+{
+    public static class RegistryUtils
+    {
+        private const string REGISTRY_UNINSTALL_KEY = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
+        private static Dictionary<string, string> installlocationscache = new Dictionary<string, string>();
+        private static List<string> displaynamescache = new List<string>();
+
+        private static void FillInternalBuffers()
+        {
+            using (Microsoft.Win32.RegistryKey key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(REGISTRY_UNINSTALL_KEY))
+            {
+                foreach (string subkey_name in key.GetSubKeyNames())
+                {
+                    using (Microsoft.Win32.RegistryKey subkey = key.OpenSubKey(subkey_name))
+                    {
+                        string str = (string)subkey.GetValue("DisplayName");
+                        if (str != null && str != "")
+                        {
+                            if (!installlocationscache.ContainsKey(str))
+                            {
+                                installlocationscache.Add(str, (string)subkey.GetValue("InstallLocation"));
+                            }
+                            displaynamescache.Add(str);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static List<string> GetUninstallDisplayNamesFiltered(string filter)
+        {
+            if(displaynamescache.Count == 0 || installlocationscache.Count == 0)
+            {
+                FillInternalBuffers();
+            }
+            List<string> results = new List<string>();
+            string lowercasefilter = filter.ToLower();
+            foreach(var str in displaynamescache)
+            {
+                if (str.ToLower().Contains(lowercasefilter))
+                {
+                    results.Add(str);
+                }
+            }
+            return results;
+        }
+
+        public static List<string> GetExecutablePathsFromDisplayUninstallDisplayName(string displayname)
+        {
+            List<string> results = new List<string>();
+            if (installlocationscache.ContainsKey(displayname))
+            {
+                string installpath = installlocationscache[displayname];
+                if (Directory.Exists(installpath))
+                {
+                    results.AddRange(Directory.GetFiles(installlocationscache[displayname], "*.exe", SearchOption.AllDirectories));
+                }
+            }
+            return results;
+        }
+    }
+}

--- a/Desktopcommands/Commands/Command_Run.cs
+++ b/Desktopcommands/Commands/Command_Run.cs
@@ -1,22 +1,50 @@
-﻿using Desktopcommands.ResponseFields;
+﻿using Desktopcommands.Commands.CommandUtilities;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics;
+using System.IO;
+using System.Windows.Input;
 
 namespace Desktopcommands.Commands
 {
     public class Command_Run : Command
     {
-        public Command_Run(string cname) : base("Command_Run")
+        string term;
+  
+        public Command_Run(string arguments) : base("Command_Run")
         {
-
+            term = arguments;
         }
 
         public override void Execute()
         {
-            throw new NotImplementedException();
+            ResponseFields.ResponseBox.SetItems(RegistryUtils.GetUninstallDisplayNamesFiltered(term));
+            ResponseFields.ResponseBox.KeyDown(SelectInstallationHandler);
+        }
+
+        public void SelectInstallationHandler(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                ResponseFields.ResponseBox.SetItems(RegistryUtils.GetExecutablePathsFromDisplayUninstallDisplayName(ResponseFields.ResponseBox.SelectedItem()));
+                ResponseFields.ResponseBox.KeyDown(RunExecutableHandler);
+            }
+            if (e.Key == Key.Escape)
+            {
+                MainWindow.AppWindow.Done();
+            }
+        }
+
+        public void RunExecutableHandler(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                Process.Start((string)ResponseFields.ResponseBox.SelectedItem());
+                MainWindow.AppWindow.Done();
+            }
+            if (e.Key == Key.Escape)
+            {
+                Execute(); //https://www.youtube.com/watch?v=uACvFAm6JSM
+            }
         }
     }
 }

--- a/Desktopcommands/Commands/Command_Run.cs
+++ b/Desktopcommands/Commands/Command_Run.cs
@@ -1,0 +1,22 @@
+﻿using Desktopcommands.ResponseFields;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Desktopcommands.Commands
+{
+    public class Command_Run : Command
+    {
+        public Command_Run(string cname) : base("Command_Run")
+        {
+
+        }
+
+        public override void Execute()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
I've added a new command which helps the user to open up already installed programs quicker. 

The user can now bring up either all or just a filtered set of his installed windows programs. After specifying which application he wants to run, the command allows him to choose from a list of associated _.exe_ files.

The application lookup (as well as the search of associated  _.exe_ files) utilize windows registry entries (specifically  _SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall_) The command does not look through desktop or start menu shortcuts (although this would be a nice addition for the future).

**Hint:** Some Applications (such as League of Legends) have missing or wrong registry entries which may mean that this command is not able to run them...